### PR TITLE
Fix Rust version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://atcoder.jp/contests/practice/custom_test
 |:---|:---|:---|
 | Ruby | 2.3.3 | https://docs.ruby-lang.org/ja/2.3.0/doc/index.html |
 | Python3  | 3.4.3 | https://docs.python.org/release/3.4.3/ |
-| Rust | 1.5.1 | https://doc.rust-lang.org/1.15.1/std/index.html |
+| Rust | 1.15.1 | https://doc.rust-lang.org/1.15.1/std/index.html |
 | Scala  | 2.11.7 | https://www.scala-lang.org/api/2.11.7/#package |
 | Haskell  | GHC 7.10.3 | https://hoogle.haskell.org/, <https://downloads.haskell.org/~ghc/7.10.3/docs/html/libraries/index.html> | 
 | Clojure  | 1.8.0 | https://clojuredocs.org/, https://clojure.github.io/clojure/branch-clojure-1.8.0/index.html |


### PR DESCRIPTION
空目ミス

やっぱコピペすべし

https://language-test-201603.contest.atcoder.jp/